### PR TITLE
Feature/dd 162

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 
 ## gradle.properties
 
-MACGYVER_VERSION=0.89.0
+MACGYVER_VERSION=0.89.1
 
 #################################
 ### third party depenedencies ###

--- a/macgyver-core/src/main/java/io/macgyver/core/rest/OkRest.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/rest/OkRest.java
@@ -203,6 +203,8 @@ public class OkRest {
 					sb.append(URLEncoder.encode(x.getKey(), "UTF8"));
 					sb.append("=");
 					sb.append(URLEncoder.encode(x.getValue(), "UTF8"));
+					
+					count++;
 				}
 			}
 			return sb.toString();

--- a/macgyver-core/src/main/java/io/macgyver/core/rest/RestException.java
+++ b/macgyver-core/src/main/java/io/macgyver/core/rest/RestException.java
@@ -28,6 +28,11 @@ public class RestException extends MacGyverException {
 		this.statusCode = statusCode;
 	}
 	
+	public RestException(int statusCode, String message) { 
+		super("status: " + statusCode + "; message: " + message);
+		this.statusCode = statusCode;
+	}
+	
 	public int getStatusCode() {
 		return statusCode;
 	}

--- a/macgyver-core/src/test/java/io/macgyver/core/rest/OkRestTest.java
+++ b/macgyver-core/src/test/java/io/macgyver/core/rest/OkRestTest.java
@@ -32,6 +32,19 @@ public class OkRestTest {
 				.toString());
 		return okRest;
 	}
+	
+	@Test
+	public void testMultiParamPath() throws IOException, InterruptedException { 
+		mockServer.enqueue(new MockResponse().setBody("{}"));
+
+		OkRest okRest = new OkRest(okClient,mockServer.getUrl("/test").toString()); 
+		okRest.queryParameter("abc", "def").queryParameter("xyz","123").request().get().execute().body();	
+		RecordedRequest rr = mockServer.takeRequest();
+		
+		Assertions.assertThat(rr.getPath()).isEqualTo("/test?abc=def&xyz=123");
+	
+	}
+	
 
 	@Test
 	public void testPath() {

--- a/macgyver-plugin-hipchat/src/main/java/io/macgyver/plugin/hipchat/HipChatClientImpl.java
+++ b/macgyver-plugin-hipchat/src/main/java/io/macgyver/plugin/hipchat/HipChatClientImpl.java
@@ -105,12 +105,13 @@ public class HipChatClientImpl implements HipChatClient {
 							.queryParameter(entry.getKey(), entry.getValue());
 				}
 			}
+			
 			Response response = rest.request().get().execute();
 			if (response.isSuccessful()) {
 				return mapper.readTree(response.body().charStream());
 			}
 
-			throw new RestException(response.code());
+			throw new RestException(response.code(), response.message());
 		} catch (IOException e) {
 			throw new RestException(e);
 		}

--- a/macgyver-plugin-hipchat/src/test/java/io/macgyver/chat/hipchat/HipChatTest.java
+++ b/macgyver-plugin-hipchat/src/test/java/io/macgyver/chat/hipchat/HipChatTest.java
@@ -3,6 +3,8 @@ package io.macgyver.chat.hipchat;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import io.macgyver.core.rest.OkRest;
 import io.macgyver.core.rest.RestException;
@@ -35,6 +37,68 @@ public class HipChatTest {
 		client = new HipChatClientImpl(mockServer.getUrl("/").toString(),
 				"dummy");
 	}
+	
+	@Test
+	public void testMultiParams() throws IOException, InterruptedException { 
+		
+		String simulatedResponse = "{\n"
+				+ "    \"items\": [\n"
+				+ "        {\n"
+				+ "            \"id\": 12345,\n"
+				+ "            \"links\": {\n"
+				+ "                \"self\": \"https://api.hipchat.com/v2/user/12345\"\n"
+				+ "            },\n"
+				+ "            \"mention_name\": \"JerryGarcia\",\n"
+				+ "            \"name\": \"Jerry Garcia\"\n"
+				+ "        }\n"
+				+ "    ],\n"
+				+ "    \"links\": {\n"
+				+ "        \"next\": \"https://api.hipchat.com/v2/user?start-index=1&max-results=1\",\n"
+				+ "        \"self\": \"https://api.hipchat.com/v2/user\"\n"
+				+ "    },\n" + "    \"maxResults\": 1,\n"
+				+ "    \"startIndex\": 0\n" + "}";
+		
+		mockServer.enqueue(new MockResponse().setBody(simulatedResponse));
+		
+		client.get("user", "max-results","1000", "expand","items");
+		RecordedRequest rr = mockServer.takeRequest();
+		
+		Assertions.assertThat(rr.getPath()).isEqualTo("/v2/user?max-results=1000&expand=items");
+		
+	}
+	
+	@Test
+	public void testParamsInMap() throws IOException, InterruptedException { 
+		String simulatedResponse = "{\n"
+				+ "    \"items\": [\n"
+				+ "        {\n"
+				+ "            \"id\": 12345,\n"
+				+ "            \"links\": {\n"
+				+ "                \"self\": \"https://api.hipchat.com/v2/user/12345\"\n"
+				+ "            },\n"
+				+ "            \"mention_name\": \"JerryGarcia\",\n"
+				+ "            \"name\": \"Jerry Garcia\"\n"
+				+ "        }\n"
+				+ "    ],\n"
+				+ "    \"links\": {\n"
+				+ "        \"next\": \"https://api.hipchat.com/v2/user?start-index=1&max-results=1\",\n"
+				+ "        \"self\": \"https://api.hipchat.com/v2/user\"\n"
+				+ "    },\n" + "    \"maxResults\": 1,\n"
+				+ "    \"startIndex\": 0\n" + "}";
+		
+		mockServer.enqueue(new MockResponse().setBody(simulatedResponse));
+		
+		Map<String, String> params = new HashMap<>();
+		params.put("max-results","1000");
+		params.put("expand","items");
+		
+		client.get("user",params);
+		RecordedRequest rr = mockServer.takeRequest();
+		
+		Assertions.assertThat(rr.getPath()).isEqualTo("/v2/user?max-results=1000&expand=items");
+		
+	}
+	
 
 	@Test
 	public void testX() throws IOException, InterruptedException {


### PR DESCRIPTION
@if6was9  passing in multiple params to the hip chat client wasn't working bc of 2 problems in OkRest:

1) if multiple key-pair args were passed in, all the values would get mapped to the first key
2)  a counter wasn't being incremented, so instead of formatting multiple params with '&' they had '?' in between them

so for example, if you passed in queryParameter("abc", "def", "123", "456"), you would expect www.something.com/blah?abc=def&123=456, but instead it was returning www.something.com/blah?abc=def?abc=123?abc=456 